### PR TITLE
Eliminate superfluous 'echo'

### DIFF
--- a/scripts/igv.sh
+++ b/scripts/igv.sh
@@ -12,7 +12,7 @@ prefix=`dirname $(readlink -f $0 || echo $0)`
 
 # Check whether or not to use the bundled JDK
 if [ -d "${prefix}/jdk-21" ]; then
-    echo echo "Using bundled JDK."
+    echo "Using bundled JDK."
     JAVA_HOME="${prefix}/jdk-21"
     PATH=$JAVA_HOME/bin:$PATH
 else


### PR DESCRIPTION
There is an 'echo' too much, when printing out, that the build-int Java version is used